### PR TITLE
chore: FORGE-602 upgrade IFrame Perspective to BrXM v17

### DIFF
--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>iframeperspective-demo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>iframeperspective-demo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>iframeperspective-demo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo</name>
   <description>IFrame Perspective Plugin Demo</description>
   <groupId>org.bloomreach.forge.iframeperspective</groupId>
   <artifactId>iframeperspective-demo</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!-- 
@@ -65,7 +65,7 @@
 
     <forge.iframeperspective.version>${project.version}</forge.iframeperspective.version>
 
-    <essentials.version>16.0.0</essentials.version>
+    <essentials.version>17.0.0</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>IFrame Perspective Plugin Demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-site</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>iframeperspective-demo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>iframeperspective-demo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.iframeperspective</groupId>
     <artifactId>iframeperspective-demo-site</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>iframeperspective-demo-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.bloomreach.forge.iframeperspective</groupId>
       <artifactId>iframeperspective-demo-components</artifactId>
-      <version>7.0.1-SNAPSHOT</version>
+      <version>8.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Bloomreach Forge IFramePerspective Plugin</name>
   <description>Bloomreach Forge IFramePerspective Plugin</description>
   <groupId>org.bloomreach.forge.iframeperspective</groupId>
   <artifactId>iframeperspective</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://bloomreach-forge.github.io/iframe-perspective/</url>
 
@@ -64,7 +64,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.onehippo.com/browse/FORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <distributionManagement>
@@ -146,8 +146,8 @@
           <scope>provided</scope>
         </dependency>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc. (https://www.bloomreach.com).
+ *  Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com).
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective10.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective10.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective2.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective2.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective3.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective3.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective4.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective4.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective5.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective5.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective6.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective6.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective7.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective7.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective8.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective8.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective9.java
+++ b/src/main/java/org/bloomreach/forge/iframeperspective/IFramePerspective9.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach, Inc.
+ *  Copyright 2026 Bloomreach, Inc.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/resources/org/bloomreach/forge/iframeperspective/IFramePerspective.html
+++ b/src/main/resources/org/bloomreach/forge/iframeperspective/IFramePerspective.html
@@ -1,5 +1,5 @@
 <!--
-  * Copyright 2024 Bloomreach
+  * Copyright 2026 Bloomreach
   *
   * Licensed under the Apache License, Version 2.0 (the  "License");
   * you may not use this file except in compliance with the License.

--- a/src/main/resources/org/bloomreach/forge/iframeperspective/iframe-perspective.css
+++ b/src/main/resources/org/bloomreach/forge/iframeperspective/iframe-perspective.css
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Bloomreach.
+ *  Copyright 2026 Bloomreach.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/resources/org/bloomreach/forge/iframeperspective/iframe-perspective.js
+++ b/src/main/resources/org/bloomreach/forge/iframeperspective/iframe-perspective.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach
+ * Copyright 2026 Bloomreach
  *
  * Licensed under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/checkstyle.xml
+++ b/src/site/checkstyle.xml
@@ -3,7 +3,7 @@
     "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <!--
-  Copyright 2024 Bloomreach
+  Copyright 2026 Bloomreach
 
   Licensed under the Apache License, Version 2.0 (the  "License");
   you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach
+  Copyright 2026 Bloomreach
 
   Licensed under the Apache License, Version 2.0 (the  "License");
   you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,7 +19,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <custom>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach Inc.
+    Copyright 2026 Bloomreach Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at

--- a/src/site/xdoc/install.xml
+++ b/src/site/xdoc/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright 2024 Bloomreach Inc.
+    Copyright 2026 Bloomreach Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at

--- a/src/site/xdoc/install_v13.xml
+++ b/src/site/xdoc/install_v13.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright 2024 Bloomreach Inc.
+    Copyright 2026 Bloomreach Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at

--- a/src/site/xdoc/non-wicket-comp-pages.xml
+++ b/src/site/xdoc/non-wicket-comp-pages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach Inc.
+    Copyright 2026 Bloomreach Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -25,6 +25,10 @@
           <th>Bloomreach XM version</th>
         </tr>
         <tr>
+          <td>8.x</td>
+          <td>17.x</td>
+        </tr>
+        <tr>
           <td>7.x</td>
           <td>16.x</td>
         </tr>
@@ -55,6 +59,14 @@
       </table>
     </section>
     <section name="Release Notes">
+      <subsection name="8.0.0">
+        <p class="smallinfo">Release date: 5 June 2026</p>
+        <ul>
+          <li><a href='https://issues.onehippo.com/browse/FORGE-602'>FORGE-602</a><br/>
+            Upgrade for compatibility with Experience Manager 17.<br/>
+          </li>
+        </ul>
+      </subsection>
       <subsection name="7.0.0">
         <p class="smallinfo">Release date: 1 July 2024</p>
         <ul>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright 2024 Bloomreach Inc.
+    Copyright 2026 Bloomreach Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at


### PR DESCRIPTION
Enables compatibility with BrXM v17 (JDK 21, Spring Boot 4). Parent poms bumped from 16.0.0 to 17.0.0; plugin version advanced to 8.0.0-SNAPSHOT. javax.annotation replaced with jakarta.annotation for Jakarta EE 10 compliance. Issue tracker URL updated from onehippo.com to bloomreach.atlassian.net.

(co-authored with Claude Code)